### PR TITLE
Refactor backend provisioning API and align frontend configuration

### DIFF
--- a/backend/provisioning_api/ai/graph.py
+++ b/backend/provisioning_api/ai/graph.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from dateparser.search import search_dates
 from langgraph.graph import END, StateGraph
 
-from ..provisioning_api.db.sql.queries import build_sql
+from provisioning_api.db.sql.queries import build_sql
 
 State = Dict[str, Any]
 
@@ -45,7 +45,7 @@ def parse_text(state: State) -> State:
     if action_match:
         filters["pri_action"] = action_match.group(1).upper()
 
-    filters.setdefault("limit", 100)
+    filters.setdefault("limit", 200)
     filters.setdefault("offset", 0)
 
     return {**state, "filters": filters, "errors": errors}
@@ -83,7 +83,7 @@ def prepare_sql(state: State) -> State:
         "start_date": filters["start_date"],
         "end_date": filters["end_date"],
         "pri_ne_id": filters["pri_ne_id"],
-        "limit": filters.get("limit", 100),
+        "limit": filters.get("limit", 200),
         "offset": filters.get("offset", 0),
     }
     if filters.get("pri_id") is not None:

--- a/backend/provisioning_api/api/deps.py
+++ b/backend/provisioning_api/api/deps.py
@@ -1,7 +1,7 @@
 """Shared API dependencies."""
 from __future__ import annotations
 
-from ..provisioning_api.core.config import Settings, get_settings
+from provisioning_api.core.config import Settings, get_settings
 
 
 def get_app_settings() -> Settings:

--- a/backend/provisioning_api/api/routes/ai.py
+++ b/backend/provisioning_api/api/routes/ai.py
@@ -1,30 +1,13 @@
-"""AI assisted endpoints."""
-from __future__ import annotations
-
-from pydantic import BaseModel
-from fastapi import APIRouter, HTTPException, status
-
-from ..provisioning_api.ai.graph import run_pipeline
-from ..provisioning_api.core.logging import logger
+from fastapi import APIRouter
+from fastapi import Body
+from provisioning_api.ai.graph import run_pipeline
 
 router = APIRouter()
 
 
-class AIRequest(BaseModel):
-    text: str
-
-
 @router.post("/ai/ask")
-async def ask_ai(payload: AIRequest):
-    """Process natural language query to derive filters and SQL."""
-
-    try:
-        result = run_pipeline(payload.text)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Error ejecutando pipeline de IA")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="No se pudo interpretar la consulta",
-        ) from exc
-
-    return result
+def ask(payload: dict = Body(...)):
+    text = str(payload.get("text", "")).strip()
+    if not text:
+        return {"filters": {}, "sql": "", "errors": ["Texto vacío."]}
+    return run_pipeline(text)

--- a/backend/provisioning_api/api/routes/export.py
+++ b/backend/provisioning_api/api/routes/export.py
@@ -1,31 +1,15 @@
-"""Export endpoints."""
-from __future__ import annotations
-
-from fastapi import APIRouter, HTTPException, status
-from fastapi.responses import Response
-
-from ..provisioning_api.core.logging import logger
-from ..provisioning_api.schemas.record import RecordsRequest
-from ..provisioning_api.services.records_service import generate_inserts
+from fastapi import APIRouter, HTTPException, Response
+from provisioning_api.schemas.record import RecordsRequest
+from provisioning_api.services.records_service import generate_inserts
 
 router = APIRouter()
 
 
 @router.post("/generate-inserts")
-async def create_inserts(payload: RecordsRequest) -> Response:
-    """Generate INSERT statements for matching records."""
-
+def post_export(body: RecordsRequest):
     try:
-        sql = generate_inserts(payload.db.model_dump(), payload.filters.model_dump())
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Error generating inserts")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="No se pudieron generar los INSERTs",
-        ) from exc
-
-    return Response(
-        content=sql,
-        media_type="application/sql",
-        headers={"Content-Disposition": "attachment; filename=provisioning_inserts.sql"},
-    )
+        sql = generate_inserts(body.db.model_dump(), body.filters.model_dump())
+        return Response(content=sql, media_type="application/sql",
+                        headers={"Content-Disposition": "attachment; filename=provisioning_inserts.sql"})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/provisioning_api/api/routes/records.py
+++ b/backend/provisioning_api/api/routes/records.py
@@ -1,26 +1,14 @@
-"""Records endpoints."""
-from __future__ import annotations
-
-from fastapi import APIRouter, HTTPException, status
-
-from ..provisioning_api.core.logging import logger
-from ..provisioning_api.schemas.record import RecordsRequest, RecordsResponse
-from ..provisioning_api.services.records_service import get_records
+from fastapi import APIRouter, HTTPException
+from provisioning_api.schemas.record import RecordsRequest, RecordsResponse, Record
+from provisioning_api.services.records_service import get_records
 
 router = APIRouter()
 
 
 @router.post("/records", response_model=RecordsResponse)
-async def read_records(payload: RecordsRequest) -> RecordsResponse:
-    """Fetch provisioning records according to provided filters."""
-
+def post_records(body: RecordsRequest):
     try:
-        items, total = get_records(payload.db.model_dump(), payload.filters.model_dump())
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Error retrieving records")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="No se pudieron obtener los registros",
-        ) from exc
-
-    return RecordsResponse(items=items, total=total)
+        items, total = get_records(body.db.model_dump(), body.filters.model_dump())
+        return {"items": [Record(**r) for r in items], "total": total}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/provisioning_api/core/config.py
+++ b/backend/provisioning_api/core/config.py
@@ -1,7 +1,7 @@
-# backend/provisioning_api/core/config.py
 from typing import List
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
+
 
 class Settings(BaseSettings):
     uvicorn_host: str = "127.0.0.1"
@@ -9,7 +9,6 @@ class Settings(BaseSettings):
     api_prefix: str = "/api"
     cors_origins: List[str] = ["http://localhost:5173", "http://127.0.0.1:5173"]
 
-    # hace que lea backend/.env automáticamente
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @field_validator("cors_origins", mode="before")
@@ -19,7 +18,9 @@ class Settings(BaseSettings):
             return [s.strip() for s in v.split(",") if s.strip()]
         return v
 
+
 _settings = Settings()
+
 
 def get_settings() -> Settings:
     return _settings

--- a/backend/provisioning_api/db/oracle.py
+++ b/backend/provisioning_api/db/oracle.py
@@ -1,59 +1,23 @@
-"""Oracle database utilities."""
-from __future__ import annotations
-
 from contextlib import contextmanager
-from typing import Any, Dict, Iterable, Iterator, List, Optional
-
 import oracledb
 
+# traer CLOB/BLOB como str/bytes
 oracledb.defaults.fetch_lobs = False
 
 
 @contextmanager
-def connect(db: Dict[str, Any]) -> Iterator[oracledb.Connection]:
-    """Yield a thin connection to Oracle using provided credentials."""
-
-    dsn = f"{db['host']}:{db['port']}/{db['service']}"
-    connection = oracledb.connect(
-        user=db["user"], password=db["password"], dsn=dsn
-    )
+def connect(db: dict):
+    dsn = f'{db["host"]}:{db["port"]}/{db["service"]}'
+    con = oracledb.connect(user=db["user"], password=db["password"], dsn=dsn)
     try:
-        yield connection
+        yield con
     finally:
-        connection.close()
+        con.close()
 
 
-def _rows_to_dicts(cursor: oracledb.Cursor, rows: Iterable[Iterable[Any]]) -> List[Dict[str, Any]]:
-    columns = [col[0].lower() for col in cursor.description]
-    return [dict(zip(columns, row)) for row in rows]
-
-
-def fetch_all(
-    connection: oracledb.Connection, sql: str, binds: Optional[Dict[str, Any]] = None
-) -> List[Dict[str, Any]]:
-    """Execute a query and return all rows as dictionaries."""
-
-    cursor = connection.cursor()
-    try:
-        cursor.execute(sql, binds or {})
-        rows = cursor.fetchall()
-        return _rows_to_dicts(cursor, rows)
-    finally:
-        cursor.close()
-
-
-def fetch_one(
-    connection: oracledb.Connection, sql: str, binds: Optional[Dict[str, Any]] = None
-) -> Optional[Dict[str, Any]]:
-    """Execute a query and return the first row as a dictionary."""
-
-    cursor = connection.cursor()
-    try:
-        cursor.execute(sql, binds or {})
-        row = cursor.fetchone()
-        if row is None:
-            return None
-        columns = [col[0].lower() for col in cursor.description]
-        return dict(zip(columns, row))
-    finally:
-        cursor.close()
+def fetch_all(con, sql: str, binds: dict) -> list[dict]:
+    cur = con.cursor()
+    cur.execute(sql, binds)
+    rows = cur.fetchall()
+    cols = [d[0].lower() for d in cur.description]
+    return [dict(zip(cols, r)) for r in rows]

--- a/backend/provisioning_api/db/sql/queries.py
+++ b/backend/provisioning_api/db/sql/queries.py
@@ -1,102 +1,46 @@
-"""SQL query builders for provisioning records."""
-from __future__ import annotations
-
-from typing import Any, Dict, Tuple
-
-SELECT_COLUMNS = """
-    a.pri_id,
-    a.pri_cellular_number,
-    a.pri_sim_msisdn,
-    a.pri_sim_imsi,
-    a.pri_action,
-    a.pri_level_action,
-    a.pri_status,
-    TO_CHAR(a.pri_action_date, 'YYYY-MM-DD HH24:MI:SS') AS pri_action_date,
-    TO_CHAR(a.pri_system_date, 'YYYY-MM-DD HH24:MI:SS') AS pri_system_date,
-    a.pri_ne_type,
-    a.pri_ne_id,
-    a.pri_ne_service,
-    a.pri_source_application,
-    a.pri_source_app_id,
-    a.pri_sis_id,
-    TO_CHAR(a.pri_error_code) AS pri_error_code,
-    a.pri_message_error,
-    a.pri_correlation_id,
-    a.pri_reason_code,
-    TO_CHAR(a.pri_processed_date, 'YYYY-MM-DD HH24:MI:SS') AS pri_processed_date,
-    TO_CHAR(a.pri_response_date, 'YYYY-MM-DD HH24:MI:SS') AS pri_response_date,
-    TO_CHAR(a.pri_priority_date, 'YYYY-MM-DD HH24:MI:SS') AS pri_priority_date,
-    TO_CHAR(a.pri_in_queue, 'YYYY-MM-DD HH24:MI:SS') AS pri_in_queue,
-    TO_CHAR(a.pri_delivered_safir, 'YYYY-MM-DD HH24:MI:SS') AS pri_delivered_safir,
-    TO_CHAR(a.pri_received_safir, 'YYYY-MM-DD HH24:MI:SS') AS pri_received_safir,
-    a.pri_id_sended,
-    a.pri_user_sender,
-    a.pri_ne_entity,
-    a.pri_acc_id,
-    a.pri_main_pri_id,
-    a.pri_resp_manager,
-    a.pri_usr_id,
-    a.pri_priority_usr,
-    a.pri_save_last_tx_status,
-    a.pri_crm_action,
-    a.pri_request,
-    a.pri_response,
-    a.pri_sended_count,
-    a.pri_main_sis_id,
-    a.pri_imei,
-    a.pri_card_number,
-    a.pri_correlator_id
-"""
-
-BASE_FROM = "FROM swp_provisioning_interfaces a"
-
-DATE_FILTER = (
-    "a.pri_action_date BETWEEN TO_DATE(:start_date, 'YYYY-MM-DD HH24:MI:SS') "
-    "AND TO_DATE(:end_date, 'YYYY-MM-DD HH24:MI:SS')"
-)
-
-
-def _build_filters(filters: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
-    conditions = [DATE_FILTER, "a.pri_ne_id = :pri_ne_id"]
-    binds: Dict[str, Any] = {
-        "start_date": filters["start_date"],
-        "end_date": filters["end_date"],
-        "pri_ne_id": filters["pri_ne_id"],
+def build_sql(filters: dict, include_pagination: bool):
+    where = [
+      "a.pri_action_date BETWEEN TO_DATE(:start_date,'YYYY-MM-DD HH24:MI:SS') AND TO_DATE(:end_date,'YYYY-MM-DD HH24:MI:SS')",
+      "a.pri_ne_id = :pri_ne_id"
+    ]
+    binds = {
+      "start_date": filters["start_date"],
+      "end_date": filters["end_date"],
+      "pri_ne_id": filters["pri_ne_id"]
     }
-
     if filters.get("pri_id") is not None:
-        conditions.append("a.pri_id = :pri_id")
+        where.append("a.pri_id = :pri_id")
         binds["pri_id"] = filters["pri_id"]
-
-    if filters.get("pri_action") is not None:
-        conditions.append("a.pri_action = :pri_action")
+    if filters.get("pri_action"):
+        where.append("a.pri_action = :pri_action")
         binds["pri_action"] = filters["pri_action"]
 
-    where_clause = " WHERE " + " AND ".join(conditions)
-    return where_clause, binds
-
-
-def build_sql(
-    filters: Dict[str, Any], include_pagination: bool = True
-) -> Tuple[str, Dict[str, Any], str, Dict[str, Any]]:
-    """Return parametrised SQL for data retrieval and counting."""
-
-    where_clause, base_binds = _build_filters(filters)
-
-    select_sql = f"SELECT\n{SELECT_COLUMNS}\n{BASE_FROM}{where_clause}\nORDER BY a.pri_action_date DESC"
-    select_binds = dict(base_binds)
-
+    select_sql = f"""
+    SELECT
+      a.pri_id, a.pri_cellular_number, a.pri_sim_msisdn, a.pri_sim_imsi, a.pri_action,
+      a.pri_level_action, a.pri_status,
+      TO_CHAR(a.pri_action_date,'YYYY-MM-DD HH24:MI:SS') AS pri_action_date,
+      TO_CHAR(a.pri_system_date,'YYYY-MM-DD HH24:MI:SS') AS pri_system_date,
+      a.pri_ne_type, a.pri_ne_id, a.pri_ne_service, a.pri_source_application, a.pri_source_app_id,
+      a.pri_sis_id, TO_CHAR(a.pri_error_code) AS pri_error_code, a.pri_message_error,
+      a.pri_correlation_id, a.pri_reason_code,
+      TO_CHAR(a.pri_processed_date,'YYYY-MM-DD HH24:MI:SS') AS pri_processed_date,
+      TO_CHAR(a.pri_response_date,'YYYY-MM-DD HH24:MI:SS') AS pri_response_date,
+      TO_CHAR(a.pri_priority_date,'YYYY-MM-DD HH24:MI:SS') AS pri_priority_date,
+      TO_CHAR(a.pri_in_queue,'YYYY-MM-DD HH24:MI:SS') AS pri_in_queue,
+      TO_CHAR(a.pri_delivered_safir,'YYYY-MM-DD HH24:MI:SS') AS pri_delivered_safir,
+      TO_CHAR(a.pri_received_safir,'YYYY-MM-DD HH24:MI:SS') AS pri_received_safir,
+      a.pri_id_sended, a.pri_user_sender, a.pri_ne_entity, a.pri_acc_id, a.pri_main_pri_id,
+      a.pri_resp_manager, a.pri_usr_id, a.pri_priority_usr,
+      a.pri_save_last_tx_status, a.pri_crm_action, a.pri_request, a.pri_response,
+      a.pri_sended_count, a.pri_main_sis_id, a.pri_imei, a.pri_card_number, a.pri_correlator_id
+    FROM swp_provisioning_interfaces a
+    WHERE { ' AND '.join(where) }
+    """
     if include_pagination:
-        select_sql += "\nOFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY"
-        select_binds["offset"] = filters.get("offset", 0)
-        select_binds["limit"] = filters.get("limit", 100)
+        select_sql += " ORDER BY a.pri_action_date DESC OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY"
+        binds["offset"] = filters.get("offset", 0)
+        binds["limit"]  = filters.get("limit", 200)
 
-    count_sql = (
-        "SELECT COUNT(1) AS total\n"
-        "FROM (\n"
-        f"    SELECT 1\n    {BASE_FROM}{where_clause}\n"
-        ")"
-    )
-    count_binds = dict(base_binds)
-
-    return select_sql, select_binds, count_sql, count_binds
+    count_sql = f"SELECT COUNT(1) AS total FROM swp_provisioning_interfaces a WHERE {' AND '.join(where)}"
+    return select_sql, count_sql, binds

--- a/backend/provisioning_api/main.py
+++ b/backend/provisioning_api/main.py
@@ -1,23 +1,31 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from ..provisioning_api.api.routes.records import router as records_router
-from ..provisioning_api.api.routes.export  import router as export_router
-from ..provisioning_api.api.routes.ai      import router as ai_router
-from ..provisioning_api.core.config        import get_settings
-from ..provisioning_api.core.logging       import configure_logging
+from provisioning_api.api.routes.records import router as records_router
+from provisioning_api.api.routes.export  import router as export_router
+from provisioning_api.api.routes.ai      import router as ai_router
+from provisioning_api.core.config        import get_settings
+from provisioning_api.core.logging       import configure_logging
 
 configure_logging()
 settings = get_settings()
 
 app = FastAPI(title="Dashboard Provisioning API")
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
+
 app.include_router(records_router, prefix=settings.api_prefix)
 app.include_router(export_router,  prefix=settings.api_prefix)
 app.include_router(ai_router,      prefix=settings.api_prefix)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/backend/provisioning_api/repositories/records_repository.py
+++ b/backend/provisioning_api/repositories/records_repository.py
@@ -1,24 +1,8 @@
-"""Repository layer responsible for Oracle interactions."""
-from __future__ import annotations
+from provisioning_api.db.oracle import fetch_all
+from provisioning_api.db.sql.queries import build_sql
 
-from typing import Any, Dict, Tuple
-
-from ..provisioning_api.db.oracle import fetch_all, fetch_one
-from ..provisioning_api.db.sql.queries import build_sql
-
-
-def fetch_records(connection, filters: Dict[str, Any]) -> Tuple[list[Dict[str, Any]], int]:
-    """Retrieve records and total count applying provided filters."""
-
-    select_sql, select_binds, count_sql, count_binds = build_sql(filters, include_pagination=True)
-    items = fetch_all(connection, select_sql, select_binds)
-    count_row = fetch_one(connection, count_sql, count_binds) or {"total": 0}
-    total = int(count_row.get("total", 0))
-    return items, total
-
-
-def fetch_all_records(connection, filters: Dict[str, Any]) -> list[Dict[str, Any]]:
-    """Retrieve all records without pagination for export purposes."""
-
-    select_sql, select_binds, _, _ = build_sql(filters, include_pagination=False)
-    return fetch_all(connection, select_sql, select_binds)
+def fetch_records(con, filters: dict, paginated: bool = True):
+    sql, count_sql, binds = build_sql(filters, include_pagination=paginated)
+    items = fetch_all(con, sql, binds)
+    total = fetch_all(con, count_sql, binds)[0]["total"] if paginated else len(items)
+    return items, int(total)

--- a/backend/provisioning_api/schemas/record.py
+++ b/backend/provisioning_api/schemas/record.py
@@ -1,17 +1,11 @@
-"""Pydantic models for provisioning records."""
-from __future__ import annotations
-
 from typing import Optional, Union
-
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel
 
 Num = Union[int, float, str]
 
 
 class Record(BaseModel):
-    """Represents a provisioning interface row."""
-
-    pri_id: Optional[Num] = None
+    pri_id: int
     pri_cellular_number: Optional[str] = None
     pri_sim_msisdn: Optional[str] = None
     pri_sim_imsi: Optional[str] = None
@@ -24,16 +18,15 @@ class Record(BaseModel):
     pri_ne_id: Optional[str] = None
     pri_ne_service: Optional[str] = None
     pri_source_application: Optional[str] = None
-    pri_source_app_id: Optional[Num] = None
+    pri_source_app_id: Optional[str] = None
     pri_sis_id: Optional[Num] = None
     pri_error_code: Optional[str] = None
     pri_message_error: Optional[str] = None
     pri_correlation_id: Optional[Num] = None
     pri_reason_code: Optional[str] = None
     pri_processed_date: Optional[str] = None
-    pri_response_date: Optional[str] = None
-    pri_priority_date: Optional[str] = None
     pri_in_queue: Optional[str] = None
+    pri_response_date: Optional[str] = None
     pri_delivered_safir: Optional[str] = None
     pri_received_safir: Optional[str] = None
     pri_id_sended: Optional[Num] = None
@@ -44,6 +37,7 @@ class Record(BaseModel):
     pri_resp_manager: Optional[str] = None
     pri_usr_id: Optional[Num] = None
     pri_priority_usr: Optional[str] = None
+    pri_priority_date: Optional[str] = None
     pri_save_last_tx_status: Optional[str] = None
     pri_crm_action: Optional[str] = None
     pri_request: Optional[str] = None
@@ -56,15 +50,11 @@ class Record(BaseModel):
 
 
 class RecordsResponse(BaseModel):
-    """Response payload containing records and total count."""
-
     items: list[Record]
     total: int
 
 
 class DBParams(BaseModel):
-    """Oracle connection parameters."""
-
     host: str
     port: int
     service: str
@@ -73,52 +63,15 @@ class DBParams(BaseModel):
 
 
 class Filters(BaseModel):
-    """Query filters for retrieving provisioning records."""
-
-    start_date: str = Field(..., description="YYYY-MM-DD HH:MM:SS")
-    end_date: str = Field(..., description="YYYY-MM-DD HH:MM:SS")
+    start_date: str
+    end_date: str
     pri_ne_id: str
-    pri_id: Optional[Num] = None
+    pri_id: Optional[int] = None
     pri_action: Optional[str] = None
-    limit: int = 100
+    limit: int = 200
     offset: int = 0
-
-    @field_validator("start_date", "end_date")
-    @classmethod
-    def validate_datetime_format(cls, value: str) -> str:
-        """Ensure the provided value matches the required datetime format."""
-
-        try:
-            date_part, time_part = value.split(" ")
-            year, month, day = date_part.split("-")
-            hour, minute, second = time_part.split(":")
-        except ValueError as exc:  # pragma: no cover - defensive
-            raise ValueError("Formato de fecha inválido, use YYYY-MM-DD HH:MM:SS") from exc
-
-        if not (
-            len(year) == 4
-            and len(month) == 2
-            and len(day) == 2
-            and len(hour) == 2
-            and len(minute) == 2
-            and len(second) == 2
-        ):
-            raise ValueError("Formato de fecha inválido, use YYYY-MM-DD HH:MM:SS")
-
-        return value
-
-    @field_validator('limit', 'offset')
-    @classmethod
-    def validate_positive(cls, value: int, info: ValidationInfo) -> int:
-        """Ensure pagination values are non-negative."""
-
-        if value < 0:
-            raise ValueError(f"{info.field_name} debe ser mayor o igual a 0")
-        return value
 
 
 class RecordsRequest(BaseModel):
-    """Full request payload containing DB params and filters."""
-
     db: DBParams
     filters: Filters

--- a/backend/provisioning_api/services/records_service.py
+++ b/backend/provisioning_api/services/records_service.py
@@ -1,27 +1,13 @@
-"""Business logic for provisioning records."""
-from __future__ import annotations
+from provisioning_api.db.oracle import connect
+from provisioning_api.repositories.records_repository import fetch_records
+from provisioning_api.utils.sql_export import generate_insert_statements
 
-from typing import Any, Dict, Tuple
+def get_records(db: dict, filters: dict):
+    with connect(db) as con:
+        return fetch_records(con, filters, paginated=True)
 
-from ..provisioning_api.db.oracle import connect
-from ..provisioning_api.repositories.records_repository import fetch_all_records, fetch_records
-from ..provisioning_api.utils.sql_export import generate_insert_statements
-
-
-def get_records(db: Dict[str, Any], filters: Dict[str, Any]) -> Tuple[list[Dict[str, Any]], int]:
-    """Retrieve records by delegating to the repository with managed connection."""
-
-    with connect(db) as connection:
-        return fetch_records(connection, filters)
-
-
-def generate_inserts(db: Dict[str, Any], filters: Dict[str, Any]) -> str:
-    """Generate INSERT statements for all records that match the filters."""
-
-    export_filters = dict(filters)
-    export_filters.pop("limit", None)
-    export_filters.pop("offset", None)
-
-    with connect(db) as connection:
-        rows = fetch_all_records(connection, export_filters)
-    return generate_insert_statements(rows)
+def generate_inserts(db: dict, filters: dict) -> str:
+    # sin paginar para exportar todo
+    with connect(db) as con:
+        items, _ = fetch_records(con, filters, paginated=False)
+        return generate_insert_statements(items)

--- a/backend/provisioning_api/utils/sql_export.py
+++ b/backend/provisioning_api/utils/sql_export.py
@@ -1,114 +1,56 @@
-"""Utilities to generate INSERT statements from query results."""
-from __future__ import annotations
-
+from typing import Any, Dict, Iterable, List
 import datetime as dt
 import re
-from typing import Any, Dict, Iterable, List
 
 COLUMNS = [
-    "pri_id",
-    "pri_cellular_number",
-    "pri_sim_msisdn",
-    "pri_sim_imsi",
-    "pri_action",
-    "pri_level_action",
-    "pri_status",
-    "pri_action_date",
-    "pri_system_date",
-    "pri_ne_type",
-    "pri_ne_id",
-    "pri_ne_service",
-    "pri_source_application",
-    "pri_source_app_id",
-    "pri_sis_id",
-    "pri_error_code",
-    "pri_message_error",
-    "pri_correlation_id",
-    "pri_reason_code",
-    "pri_processed_date",
-    "pri_response_date",
-    "pri_priority_date",
-    "pri_in_queue",
-    "pri_delivered_safir",
-    "pri_received_safir",
-    "pri_id_sended",
-    "pri_user_sender",
-    "pri_ne_entity",
-    "pri_acc_id",
-    "pri_main_pri_id",
-    "pri_resp_manager",
-    "pri_usr_id",
-    "pri_priority_usr",
-    "pri_save_last_tx_status",
-    "pri_crm_action",
-    "pri_request",
-    "pri_response",
-    "pri_sended_count",
-    "pri_main_sis_id",
-    "pri_imei",
-    "pri_card_number",
-    "pri_correlator_id",
+  "pri_id","pri_cellular_number","pri_sim_msisdn","pri_sim_imsi","pri_action",
+  "pri_level_action","pri_status","pri_action_date","pri_system_date","pri_ne_type",
+  "pri_ne_id","pri_ne_service","pri_source_application","pri_source_app_id","pri_sis_id",
+  "pri_error_code","pri_message_error","pri_correlation_id","pri_reason_code","pri_processed_date",
+  "pri_response_date","pri_priority_date","pri_in_queue","pri_delivered_safir","pri_received_safir",
+  "pri_id_sended","pri_user_sender","pri_ne_entity","pri_acc_id","pri_main_pri_id","pri_resp_manager",
+  "pri_usr_id","pri_priority_usr","pri_save_last_tx_status","pri_crm_action","pri_request","pri_response",
+  "pri_sended_count","pri_main_sis_id","pri_imei","pri_card_number","pri_correlator_id"
 ]
 
 RAW_OVERRIDES = {
-    "pri_id": "(SELECT NVL(MAX(pri_id), 0) + 1 FROM swp_provisioning_interfaces)",
-    "pri_action_date": "TO_DATE('30-04-2025 00:00:01', 'DD-MM-YYYY HH24:MI:SS')",
-    "pri_system_date": "TO_DATE('30-04-2025 00:00:01', 'DD-MM-YYYY HH24:MI:SS')",
+  "pri_id": "(SELECT NVL(MAX(pri_id), 0) + 1 FROM swp_provisioning_interfaces)",
+  "pri_action_date": "TO_DATE('30-04-2025 00:00:01', 'DD-MM-YYYY HH24:MI:SS')",
+  "pri_system_date": "TO_DATE('30-04-2025 00:00:01', 'DD-MM-YYYY HH24:MI:SS')",
 }
 
-DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
-NUMERIC_PATTERN = re.compile(r"^-?\d+(?:\.\d+)?$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
+NUM_RE  = re.compile(r"^-?\d+(?:\.\d+)?$")
 
 
-def esc(value: Any) -> str:
-    """Escape values for SQL INSERT statements respecting data types."""
-
-    if value is None:
-        return "NULL"
-
-    if isinstance(value, (int, float)):
-        return str(value)
-
-    if isinstance(value, dt.datetime):
-        formatted = value.strftime("%Y-%m-%d %H:%M:%S")
-        return f"TO_DATE('{formatted}', 'YYYY-MM-DD HH24:MI:SS')"
-
-    if isinstance(value, dt.date):
-        formatted = value.strftime("%Y-%m-%d 00:00:00")
-        return f"TO_DATE('{formatted}', 'YYYY-MM-DD HH24:MI:SS')"
-
-    if isinstance(value, str):
-        value = value.strip()
-        if DATE_PATTERN.match(value):
-            return f"TO_DATE('{value}', 'YYYY-MM-DD HH24:MI:SS')"
-        if NUMERIC_PATTERN.match(value):
-            return value
-        escaped = value.replace("'", "''")
-        return f"'{escaped}'"
-
-    return f"'{str(value).replace("'", "''")}'"
+def esc(v: Any) -> str:
+    if v is None: return "NULL"
+    if isinstance(v, (int, float)): return str(v)
+    if isinstance(v, dt.datetime):
+        s = v.strftime("%Y-%m-%d %H:%M:%S"); return f"TO_DATE('{s}','YYYY-MM-DD HH24:MI:SS')"
+    if isinstance(v, dt.date):
+        s = v.strftime("%Y-%m-%d 00:00:00"); return f"TO_DATE('{s}','YYYY-MM-DD HH24:MI:SS')"
+    s = str(v).strip()
+    if DATE_RE.match(s): return f"TO_DATE('{s}','YYYY-MM-DD HH24:MI:SS')"
+    if NUM_RE.match(s):  return s
+    s_esc = s.replace("'", "''")
+    return f"'{s_esc}'"
 
 
 def _format_row(row: Dict[str, Any]) -> List[str]:
-    formatted: List[str] = []
-    for column in COLUMNS:
-        if column in RAW_OVERRIDES:
-            formatted.append(RAW_OVERRIDES[column])
-            continue
-        formatted.append(esc(row.get(column)))
-    return formatted
+    out: List[str] = []
+    for col in COLUMNS:
+        if col in RAW_OVERRIDES:
+            out.append(RAW_OVERRIDES[col])
+        else:
+            out.append(esc(row.get(col)))
+    return out
 
 
 def generate_insert_statements(rows: Iterable[Dict[str, Any]]) -> str:
-    """Generate INSERT statements for the given rows."""
-
-    statements: List[str] = []
-    for row in rows:
-        values = ", ".join(_format_row(row))
-        statement = (
-            "INSERT INTO swp_provisioning_interfaces ("
-            + ", ".join(COLUMNS)
-            + f") VALUES ({values});"
-        )
-        statements.append(statement)
-    return "\n".join(statements)
+    lines: List[str] = []
+    cols = ", ".join(COLUMNS)
+    for r in rows:
+        values = ", ".join(_format_row(r))
+        lines.append(f"INSERT INTO swp_provisioning_interfaces ({cols}) VALUES ({values});")
+    return "\n".join(lines) + "\n"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,8 @@
-fastapi==0.110.2
-uvicorn[standard]==0.29.0
-python-oracledb==1.4.2
-pydantic==2.7.1
-dateparser==1.2.0
-langgraph==0.0.63
+fastapi
+uvicorn[standard]
+oracledb
+python-dotenv
+pydantic>=2.3
+pydantic-settings>=2.2
+dateparser
+langgraph

--- a/backend/run.py
+++ b/backend/run.py
@@ -3,6 +3,4 @@ from provisioning_api.core.config import get_settings
 
 if __name__ == "__main__":
     s = get_settings()
-    uvicorn.run("provisioning_api.main:app",
-                host=s.uvicorn_host, port=s.uvicorn_port,
-                reload=True, app_dir="backend")
+    uvicorn.run("provisioning_api.main:app", host=s.uvicorn_host, port=s.uvicorn_port, reload=True)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import NLSearch from './components/NLSearch';
 import DbForm from './components/DbForm';
 import FiltersForm from './components/Filters';
 import ResultsTable from './components/ResultsTable';
-import { AskAi, downloadInserts, postRecords } from './lib/api';
+import { askAi, downloadInserts, postRecords } from './lib/api';
 import { AskAiResponse, DbCredentials, Filters, RecordItem } from './types';
 
 const DEFAULT_LIMIT = 200;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,42 +1,33 @@
-// frontend/src/lib/api.ts
-const BASE = (import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000/api').replace(/\/+$/,'');
+const BASE = (import.meta.env.VITE_API_URL || "http://127.0.0.1:8000/api").replace(/\/+$/,"");
 
 async function postJSON<T>(path: string, body: any): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`HTTP ${res.status} ${res.statusText}${text ? ' - ' + text : ''}`);
+    const text = await res.text().catch(()=> "");
+    throw new Error(`HTTP ${res.status} ${res.statusText}${text? " - " + text : ""}`);
   }
   return res.json() as Promise<T>;
 }
 
-export function postRecords(payload: any) {
-  return postJSON<{ items: any[]; total: number }>('/records', payload);
-}
+export const postRecords = (payload: any) =>
+  postJSON<{ items: any[]; total: number }>("/records", payload);
 
 export async function downloadInserts(payload: any) {
   const res = await fetch(`${BASE}/generate-inserts`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`HTTP ${res.status} ${res.statusText}${text ? ' - ' + text : ''}`);
-  }
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'provisioning_inserts.sql';
-  a.click();
+  const a = document.createElement("a");
+  a.href = url; a.download = "provisioning_inserts.sql"; a.click();
   URL.revokeObjectURL(url);
 }
 
-export function askAi(text: string) {
-  return postJSON<{ filters: any; sql: string; errors: string[] }>('/ai/ask', { text });
-}
+export const askAi = (text: string) => postJSON<{filters:any; sql:string; errors:string[]}>("/ai/ask", { text });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,8 +1,13 @@
-// frontend/src/types.ts
 export type DbCredentials = { host: string; port: number; service: string; user: string; password: string; };
 export type Filters = {
   start_date: string; end_date: string; pri_ne_id: string;
-  pri_id?: number; pri_action?: string; limit?: number; offset?: number;
+  pri_id?: string; pri_action?: string; limit: number; offset: number;
 };
 export type RecordItem = Record<string, string | number | null>;
-export type AskAiResponse = { filters: Partial<Filters>; sql: string; errors: string[] };
+export type AskAiResponse = {
+  filters: {
+    start_date?: string; end_date?: string; pri_ne_id?: string | number;
+    pri_id?: string | number; pri_action?: string; limit?: number; offset?: number;
+  };
+  sql: string; errors: string[];
+};

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -3,7 +3,15 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "lib": [
+      "ES2021"
+    ],
+    "skipLibCheck": true
   },
-  "include": ["vite.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "vite.config.d.ts",
+    "types/node-shim.d.ts"
+  ]
 }

--- a/frontend/types/node-shim.d.ts
+++ b/frontend/types/node-shim.d.ts
@@ -1,0 +1,4 @@
+declare module "node:*" {
+  const value: any;
+  export = value;
+}


### PR DESCRIPTION
## Summary
- update backend configuration, entrypoint, and main FastAPI app to consume environment settings and expose consistent routers and health check
- simplify Oracle access, SQL construction, Pydantic schemas, repository/service layers, and LangGraph pipeline under the `provisioning_api` package namespace
- align frontend API client, types, and Vite TypeScript configuration with the backend contract and new base URL handling

## Testing
- python -m compileall backend/provisioning_api
- npm run build *(fails: `vite` command and Rollup native package unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a25fa630832c9e0526eee7630594