### PR TITLE
Fix records count binds and enhance AI query parsing

### DIFF
--- a/backend/provisioning_api/ai/graph.py
+++ b/backend/provisioning_api/ai/graph.py
@@ -1,120 +1,257 @@
-"""LangGraph pipeline to interpret natural language queries."""
+# backend/provisioning_api/ai/graph.py
 from __future__ import annotations
-
+from typing import TypedDict, Dict, Any, Optional, Tuple
+from datetime import datetime, timedelta
 import re
-from datetime import datetime
-from typing import Any, Dict
+import dateparser
 
-from dateparser.search import search_dates
-from langgraph.graph import END, StateGraph
-
+from langgraph.graph import StateGraph, END
 from provisioning_api.db.sql.queries import build_sql
 
-State = Dict[str, Any]
+class State(TypedDict, total=False):
+    text: str
+    filters: Dict[str, Any]
+    errors: list[str]
+    sql: str
 
+# ----------------- helpers de tiempo -----------------
 
-def _normalise_datetime(value: datetime) -> str:
-    return value.replace(microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+SPAN = Tuple[datetime, datetime]
 
+def _day_bounds(d: datetime) -> SPAN:
+    return d.replace(hour=0, minute=0, second=0, microsecond=0), d.replace(hour=23, minute=59, second=59, microsecond=0)
+
+def _week_bounds(d: datetime) -> SPAN:
+    # lunes-domingo
+    start = (d - timedelta(days=d.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = (start + timedelta(days=6)).replace(hour=23, minute=59, second=59, microsecond=0)
+    return start, end
+
+def _month_bounds(d: datetime) -> SPAN:
+    start = d.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if d.month == 12:
+        nxt = d.replace(year=d.year + 1, month=1, day=1)
+    else:
+        nxt = d.replace(month=d.month + 1, day=1)
+    end = (nxt - timedelta(seconds=1)).replace(microsecond=0)
+    return start, end
+
+def _quarter_bounds(d: datetime) -> SPAN:
+    q = (d.month - 1) // 3
+    first_month = q * 3 + 1
+    start = d.replace(month=first_month, day=1, hour=0, minute=0, second=0, microsecond=0)
+    # siguiente trimestre
+    if first_month == 10:
+        nxt = d.replace(year=d.year + 1, month=1, day=1)
+    else:
+        nxt = d.replace(month=first_month + 3, day=1)
+    end = (nxt - timedelta(seconds=1)).replace(microsecond=0)
+    return start, end
+
+def _year_bounds(d: datetime) -> SPAN:
+    start = d.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = d.replace(month=12, day=31, hour=23, minute=59, second=59, microsecond=0)
+    return start, end
+
+def _parse_range_free(text: str, now: Optional[datetime] = None) -> SPAN:
+    """
+    Soporta en español (sin LLM):
+    - “del X al Y”, “desde X hasta Y”, “entre X y Y”
+    - “hoy”, “ayer”, “anteayer”
+    - “últimos/ultimas N (días|semanas|meses|años|horas)”
+    - “hace N (días|semanas|meses|años|horas)”  -> [now-N, now]
+    - “esta semana/mes/trimestre/año”
+    - “semana/mes/trimestre/año pasado(a)”
+    - “este fin de semana”, “fin de semana pasado”
+    - “principio/inicio/comienzo de <mes> [de <año>] ... (hasta hoy)”
+    - “este mes hasta hoy”, “esta semana hasta hoy” (fin = hoy)
+    """
+    now = now or datetime.now()
+    base_parse = lambda s: dateparser.parse(s, languages=["es"], settings={"PREFER_DATES_FROM": "past"})  # type: ignore
+
+    t = re.sub(r"\s+", " ", text.strip().lower())
+
+    # Rango explícito
+    m = re.search(r"\b(?:del|desde)\s+(.+?)\s+(?:al|hasta)\s+(.+?)\b", t)
+    if not m:
+        m = re.search(r"\bentre\s+(.+?)\s+y\s+(.+?)\b", t)
+    if m:
+        s = base_parse(m.group(1))
+        e = base_parse(m.group(2))
+        if s and e:
+            s0, e0 = _day_bounds(s) if s.time() == datetime.min.time() else (s, s)
+            e0 = e.replace(microsecond=0)
+            if e.time() == datetime.min.time():
+                _, e0 = _day_bounds(e)
+            return s0, e0
+
+    # Hoy / Ayer / Anteayer
+    if re.search(r"\bhoy\b", t):
+        return _day_bounds(now)
+    if re.search(r"\banteayer\b", t):
+        return _day_bounds(now - timedelta(days=2))
+    if re.search(r"\bayer\b", t) or re.search(r"\bay er\b", t):  # por si meten espacios raros
+        return _day_bounds(now - timedelta(days=1))
+
+    # Últimos N unidades
+    m = re.search(r"\búltim[oa]s?\s+(\d+)\s+(d[ií]as?|semanas?|meses?|a[nñ]os?|horas?)\b", t)
+    if m:
+        n = int(m.group(1)); unit = m.group(2)
+        delta = {"día": "days", "dias": "days", "días": "days", "semana": "weeks", "semanas": "weeks",
+                 "mes": "months", "meses": "months", "año": "years", "años": "years", "hora": "hours", "horas": "hours"}
+        u = "days"
+        if "seman" in unit: u = "weeks"
+        elif "mes" in unit: u = "months"
+        elif "a" in unit and "ño" in unit: u = "years"
+        elif "hora" in unit: u = "hours"
+        end = now
+        if u == "weeks": start = now - timedelta(weeks=n)
+        elif u == "months":
+            # retroceso mes a mes
+            y, mth = now.year, now.month
+            for _ in range(n):
+                if mth == 1: y, mth = y - 1, 12
+                else: mth -= 1
+            start = now.replace(year=y, month=mth)
+        elif u == "years": start = now.replace(year=now.year - n)
+        elif u == "hours":
+            start = now - timedelta(hours=n)
+        else:
+            start = now - timedelta(days=n)
+        s0 = start.replace(minute=0, second=0, microsecond=0) if u == "hours" else _day_bounds(start)[0]
+        e0 = end.replace(microsecond=0)
+        return s0, e0
+
+    # Hace N unidades (desde hace N hasta ahora)
+    m = re.search(r"\bhace\s+(\d+)\s+(d[ií]as?|semanas?|meses?|a[nñ]os?|horas?)\b", t)
+    if m:
+        n = int(m.group(1)); unit = m.group(2)
+        if "seman" in unit: start = now - timedelta(weeks=n)
+        elif "mes" in unit:
+            y, mth = now.year, now.month
+            for _ in range(n):
+                if mth == 1: y, mth = y - 1, 12
+                else: mth -= 1
+            start = now.replace(year=y, month=mth)
+        elif "a" in unit and "ño" in unit: start = now.replace(year=now.year - n)
+        elif "hora" in unit: start = now - timedelta(hours=n)
+        else: start = now - timedelta(days=n)
+        s0 = start.replace(minute=0, second=0, microsecond=0) if "hora" in unit else _day_bounds(start)[0]
+        return s0, now.replace(microsecond=0)
+
+    # Esta/este … / pasada(o)
+    if re.search(r"\best[ae]\s+semana\b", t):
+        s, e = _week_bounds(now)
+        e = min(e, now.replace(hour=23, minute=59, second=59, microsecond=0))
+        return s, e
+    if re.search(r"\bsemana\s+pasad[ao]\b", t):
+        s, _ = _week_bounds(now - timedelta(days=7))
+        return s, (s + timedelta(days=6)).replace(hour=23, minute=59, second=59, microsecond=0)
+
+    if re.search(r"\best[ea]\s+mes\b", t):
+        s, e = _month_bounds(now)
+        e = min(e, now.replace(hour=23, minute=59, second=59, microsecond=0))
+        return s, e
+    if re.search(r"\bmes\s+pasad[oa]\b", t):
+        prev = now.replace(day=1) - timedelta(days=1)
+        s, e = _month_bounds(prev)
+        return s, e
+
+    if re.search(r"\best[ea]\s+trimestre\b", t):
+        s, e = _quarter_bounds(now); e = min(e, now.replace(hour=23, minute=59, second=59, microsecond=0)); return s, e
+    if re.search(r"\btrimestre\s+pasad[oa]\b", t):
+        s, _ = _quarter_bounds(now.replace(month=((now.month - 4) % 12) + 1))
+        e = _quarter_bounds(s)[1]; return s, e
+
+    if re.search(r"\best[ea]\s+a[nñ]o\b", t):
+        s, e = _year_bounds(now); e = min(e, now.replace(hour=23, minute=59, second=59, microsecond=0)); return s, e
+    if re.search(r"\ba[nñ]o\s+pasad[oa]\b", t):
+        s, e = _year_bounds(now.replace(year=now.year - 1)); return s, e
+
+    # Fin de semana
+    if re.search(r"\bfin\s+de\s+semana\s+pasad[oa]?\b", t):
+        # sábado y domingo pasados
+        last_sun = now - timedelta(days=(now.weekday() + 1))
+        sat = last_sun - timedelta(days=1)
+        return _day_bounds(sat)[0], _day_bounds(last_sun)[1]
+    if re.search(r"\beste\s+fin\s+de\s+semana\b", t):
+        # siguiente fin de semana del período actual
+        wstart, _ = _week_bounds(now)
+        sat = wstart + timedelta(days=5)
+        sun = sat + timedelta(days=1)
+        return _day_bounds(sat)[0], _day_bounds(sun)[1]
+
+    # Principio/inicio/comienzo de <mes> [de <año>] (hasta hoy si no hay fin)
+    m = re.search(r"(?:principio|inicio|comienzo)\s+de\s+([a-záéíóú]+)(?:\s+de\s+(\d{4}))?", t)
+    if m:
+        month = m.group(1); year = int(m.group(2)) if m.group(2) else now.year
+        s = dateparser.parse(f"1 {month} {year}", languages=["es"])
+        if s:
+            _, e = _day_bounds(now)
+            return _day_bounds(s)[0], e
+
+    # Fallback: hoy
+    return _day_bounds(now)
+
+# ----------------- NODOS -----------------
 
 def parse_text(state: State) -> State:
-    text: str = state.get("text", "")
-    filters = dict(state.get("filters", {}))
-    errors = list(state.get("errors", []))
+    txt = str(state.get("text",""))
+    filters: Dict[str, Any] = {}
 
-    date_matches = search_dates(text, languages=["es"]) or []
-    if date_matches:
-        dates = sorted({match[1] for match in date_matches})
-        start = dates[0]
-        end = dates[-1]
-        filters["start_date"] = _normalise_datetime(start)
-        filters["end_date"] = _normalise_datetime(end)
+    # pri_ne_id: acepta “pri_ne_id DTH”, “pri_ne_id=DTH”, “para/en/sobre el DTH”, “ne id DTH”
+    m = re.search(r"\bpri[_\s-]?ne[_\s-]?id\b(?:\s*(?:=|:)\s*|\s+(?:es|de)?\s*)?([a-z0-9_-]{2,})\b", txt, flags=re.I)
+    if not m:
+        m = re.search(r"\b(?:en|para|sobre)\s+(?:el|la|los|las)?\s*([a-z0-9_-]{2,})\b", txt, flags=re.I)
+    if not m:
+        m = re.search(r"\bne\s*id\b\s*[:=]?\s*([a-z0-9_-]{2,})\b", txt, flags=re.I)
+    if m:
+        filters["pri_ne_id"] = m.group(1).upper()
 
-    ne_match = re.search(r"\b([A-Z]{3}\d+)\b", text.upper())
-    if ne_match:
-        filters["pri_ne_id"] = ne_match.group(1)
+    m = re.search(r"\bpri_id\s*[:=]\s*(\d+)\b", txt, flags=re.I)
+    if m: filters["pri_id"] = int(m.group(1))
 
-    pri_id_match = re.search(r"pri[_\s-]*id\s*(\d+)", text.lower())
-    if pri_id_match:
-        filters["pri_id"] = int(pri_id_match.group(1))
+    m = re.search(r"\bpri_action\s*[:=]\s*([a-z0-9_-]+)\b", txt, flags=re.I)
+    if not m:
+        m = re.search(r"\b(?:action|acciones?)\s+([a-z0-9_-]+)\b", txt, flags=re.I)
+    if m: filters["pri_action"] = m.group(1).upper()
 
-    action_match = re.search(
-        r"\b(alta|baja|modificacion|modificación|consulta|update|delete)\b",
-        text.lower(),
-    )
-    if action_match:
-        filters["pri_action"] = action_match.group(1).upper()
-
+    start, end = _parse_range_free(txt)
+    filters["start_date"] = start.strftime("%Y-%m-%d %H:%M:%S")
+    filters["end_date"]   = end.strftime("%Y-%m-%d %H:%M:%S")
     filters.setdefault("limit", 200)
     filters.setdefault("offset", 0)
 
-    return {**state, "filters": filters, "errors": errors}
-
+    state["filters"] = filters
+    state["errors"] = [] if filters.get("pri_ne_id") else ["Falta pri_ne_id"]
+    return state
 
 def validate(state: State) -> State:
-    filters = state.get("filters", {})
-    errors = list(state.get("errors", []))
-
-    required = ["start_date", "end_date", "pri_ne_id"]
-    for field in required:
-        if not filters.get(field):
-            errors.append(f"Falta {field}")
-
-    if "start_date" in filters and "end_date" in filters:
-        try:
-            start = datetime.strptime(filters["start_date"], "%Y-%m-%d %H:%M:%S")
-            end = datetime.strptime(filters["end_date"], "%Y-%m-%d %H:%M:%S")
-            if start > end:
-                errors.append("start_date no puede ser mayor que end_date")
-        except ValueError:
-            errors.append("Formato de fecha inválido")
-
-    return {**state, "errors": errors}
-
+    # validación mínima de formato, ya vienen normalizadas
+    errs = []
+    f = state["filters"]
+    if not f.get("pri_ne_id"): errs.append("Falta pri_ne_id")
+    state["errors"] = errs
+    return state
 
 def prepare_sql(state: State) -> State:
-    errors = state.get("errors", [])
-    filters = state.get("filters", {})
+    if state.get("errors"): return state
+    f = state["filters"]
+    sql, _, _ = build_sql(f, include_pagination=True)
+    state["sql"] = sql
+    return state
 
-    if errors:
-        return {**state, "sql": None}
-
-    base_filters: Dict[str, Any] = {
-        "start_date": filters["start_date"],
-        "end_date": filters["end_date"],
-        "pri_ne_id": filters["pri_ne_id"],
-        "limit": filters.get("limit", 200),
-        "offset": filters.get("offset", 0),
-    }
-    if filters.get("pri_id") is not None:
-        base_filters["pri_id"] = filters["pri_id"]
-    if filters.get("pri_action"):
-        base_filters["pri_action"] = filters["pri_action"].upper()
-
-    select_sql, _, _, _ = build_sql(base_filters, include_pagination=False)
-    return {**state, "filters": base_filters, "sql": select_sql}
-
-
-graph = StateGraph(dict)
+graph = StateGraph(State)
 graph.add_node("parse_text", parse_text)
 graph.add_node("validate", validate)
 graph.add_node("prepare_sql", prepare_sql)
-
 graph.set_entry_point("parse_text")
 graph.add_edge("parse_text", "validate")
 graph.add_edge("validate", "prepare_sql")
 graph.add_edge("prepare_sql", END)
 
-workflow = graph.compile()
+app_graph = graph.compile()
 
-
-def run_pipeline(text: str) -> Dict[str, Any]:
-    """Run the natural language pipeline and return filters and SQL."""
-
-    initial_state: State = {"text": text, "filters": {}, "errors": [], "sql": None}
-    result = workflow.invoke(initial_state)
-    return {
-        "filters": result.get("filters", {}),
-        "sql": result.get("sql"),
-        "errors": result.get("errors", []),
-    }
+def run_pipeline(text: str) -> dict:
+    out = app_graph.invoke({"text": text})
+    return {"filters": out.get("filters", {}), "sql": out.get("sql",""), "errors": out.get("errors", [])}

--- a/backend/provisioning_api/api/routes/ai.py
+++ b/backend/provisioning_api/api/routes/ai.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter
-from fastapi import Body
+from fastapi import APIRouter, Body
 from provisioning_api.ai.graph import run_pipeline
 
 router = APIRouter()

--- a/backend/provisioning_api/repositories/records_repository.py
+++ b/backend/provisioning_api/repositories/records_repository.py
@@ -2,7 +2,16 @@ from provisioning_api.db.oracle import fetch_all
 from provisioning_api.db.sql.queries import build_sql
 
 def fetch_records(con, filters: dict, paginated: bool = True):
-    sql, count_sql, binds = build_sql(filters, include_pagination=paginated)
-    items = fetch_all(con, sql, binds)
-    total = fetch_all(con, count_sql, binds)[0]["total"] if paginated else len(items)
+    select_sql, count_sql, binds = build_sql(filters, include_pagination=paginated)
+
+    # Items con todos los binds
+    items = fetch_all(con, select_sql, binds)
+
+    # Count sin offset/limit
+    if paginated:
+        binds_count = {k: v for k, v in binds.items() if k not in ("offset", "limit")}
+    else:
+        binds_count = binds
+
+    total = fetch_all(con, count_sql, binds_count)[0]["total"] if count_sql else len(items)
     return items, int(total)


### PR DESCRIPTION
## Summary
- adjust records repository to reuse pagination binds for items while removing offset/limit when counting
- replace the LangGraph pipeline with a richer Spanish time parser and pri_ne_id detection while preserving SQL preparation
- streamline the AI router import while returning empty-text validation

## Testing
- ⚠️ `PYTHONPATH=backend python - <<'PY'
from provisioning_api.ai.graph import run_pipeline
run_pipeline('para el pri_ne_id DTH todas las pri_action de principio de septiembre hasta hoy')
PY
` *(fails: ModuleNotFoundError: No module named 'dateparser' due to blocked dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b2dfe630832cae250b906deb8ddd