### PR TITLE
Improve Oracle fallback to THICK mode and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ uvicorn provisioning_api.main:provisioning_api --reload
 
 La API queda disponible en `http://localhost:8000`.
 
+> ℹ️ **Conexión a Oracle**
+>
+> - Las bases de datos antiguas (por ejemplo 11g/12c sin parches recientes) requieren el modo **THICK**, que necesita Oracle Instant Client 19 u 21. Activá el modo thick seteando `FORCE_ORACLE_THICK=1` o dejá que la API cambie automáticamente cuando el driver devuelva `DPY-3010`.
+> - Si el servidor exige modo THICK y no encuentra las librerías nativas, instalá Oracle Instant Client y apuntá `ORACLE_CLIENT_LIB_DIR` al directorio donde lo descomprimiste (también podés agregarlo al `PATH`). En Windows es obligatorio instalar el **Microsoft Visual C++ Redistributable 2017-2022 x64**, descomprimir el Instant Client y luego reiniciar la terminal.
+> - Cuando la base publica un **SID** en lugar de un service name, podés cargar `host:puerto:SID` directamente en el campo “Service”; la API ajustará los parámetros al conectarse.
+
 ### Frontend
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+# Forzá modo THICK cuando trabajás con servidores antiguos o clientes con políticas estrictas.
+FORCE_ORACLE_THICK=0
+# En Windows seteá esta ruta al directorio del Instant Client (ej.: C:\\oracle\\instantclient_19_23)
+# ORACLE_CLIENT_LIB_DIR=

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,6 +19,12 @@ uvicorn provisioning_api.main:provisioning_api --reload
 
 La API queda disponible en `http://localhost:8000` y permite solicitudes desde `http://localhost:5173`.
 
+### Conexión a Oracle
+
+- Los servidores Oracle antiguos (11g/12c) suelen requerir modo **THICK**. Instalá Oracle Instant Client 19 u 21 y seteá `FORCE_ORACLE_THICK=1` o dejá que el backend reintente en THICK cuando el driver devuelva `DPY-3010`.
+- Si no encuentra el Instant Client, definí `ORACLE_CLIENT_LIB_DIR` (o agregá la carpeta al `PATH`). En Windows necesitás el Microsoft Visual C++ Redistributable 2017-2022 x64 antes de descomprimir el Instant Client.
+- Para bases identificadas por **SID**, podés cargar `host:puerto:SID` en el campo "Service"; el backend lo interpretará automáticamente.
+
 ### Endpoints principales
 
 - `POST /api/records`

--- a/backend/provisioning_api/db/oracle.py
+++ b/backend/provisioning_api/db/oracle.py
@@ -1,85 +1,219 @@
-# backend/provisioning_api/db/oracle.py
+"""Utilidades de conexión a Oracle con fallback automático a modo THICK."""
+from __future__ import annotations
+
 from contextlib import contextmanager
+from functools import lru_cache
 import os
 import socket
+from typing import Any
+
 import oracledb
 
 # Traer CLOB/BLOB como str/bytes
 oracledb.defaults.fetch_lobs = False
 
-def _init_thick_if_configured():
-    """Inicializa modo thick si hay Instant Client disponible."""
+_NETWORK_HINT = (
+    "No se puede conectar al listener {host}:{port}. "
+    "Verificá VPN/firewall y que el listener esté activo. Detalle: {detail}"
+)
+
+
+def _to_bool(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _should_force_thick() -> bool:
+    return _to_bool(os.getenv("FORCE_ORACLE_THICK"))
+
+
+@lru_cache(maxsize=1)
+def _ensure_thick_mode() -> None:
+    """Inicializa el cliente en modo THICK si es necesario."""
     if not oracledb.is_thin_mode():
+        # Ya estamos en modo THICK.
         return
+
     lib_dir = os.getenv("ORACLE_CLIENT_LIB_DIR")
+    kwargs: dict[str, Any] = {}
+    if lib_dir:
+        kwargs["lib_dir"] = lib_dir
+
     try:
-        if lib_dir:
-            oracledb.init_oracle_client(lib_dir=lib_dir)
-        else:
-            # si el instant client está en PATH, esto alcanza
-            oracledb.init_oracle_client()
-    except Exception:
-        # si ya estaba inicializado o no hay client, dejamos que el connect falle como siempre
-        pass
+        oracledb.init_oracle_client(**kwargs)
+    except Exception as exc:  # pragma: no cover - depende de la instalación local
+        raise RuntimeError(
+            "No se pudo iniciar Oracle Instant Client. "
+            "Instalá Instant Client 19 u 21 y configurá ORACLE_CLIENT_LIB_DIR "
+            "o agregalo al PATH. Detalle: {0}".format(exc)
+        ) from exc
 
-def _dsn_service(host: str, port: int, service: str) -> str:
-    # service_name primero (lo más común)
-    return oracledb.makedsn(host, port, service_name=service)
 
-def _dsn_sid(host: str, port: int, sid: str) -> str:
-    # fallback a SID cuando el listener no tiene el service_name
-    return oracledb.makedsn(host, port, sid=sid)
+def _require_thick_mode(reason: str) -> None:
+    try:
+        _ensure_thick_mode()
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "El servidor requiere modo THICK pero no está disponible. "
+            f"Motivo: {reason}. {exc}"
+        ) from exc
 
-@contextmanager
-def connect(db: dict):
+
+def _parse_connection_fields(db: dict[str, Any]) -> tuple[str, int, str | None, str | None]:
     host = db["host"].strip()
     port = int(db["port"])
-    service = db["service"].strip()
+    raw_service = db["service"].strip()
 
-    # 1) DNS upfront para mensaje claro
+    # Permitir host:port:SID en el campo Service
+    sid = None
+    service_name: str | None = raw_service or None
+    if raw_service.count(":") >= 2:
+        maybe_host, maybe_port, maybe_sid = raw_service.split(":", 2)
+        if maybe_host and maybe_port.isdigit() and maybe_sid:
+            host = maybe_host.strip()
+            port = int(maybe_port)
+            sid = maybe_sid.strip()
+            service_name = None
+
+    return host, port, service_name, sid
+
+
+def _resolve_dns(host: str) -> None:
     try:
         socket.getaddrinfo(host, None)
-    except socket.gaierror as e:
-        raise RuntimeError(f"No se puede resolver el host '{host}' (DNS/VPN). Detalle: {e}")
+    except socket.gaierror as exc:
+        raise RuntimeError(
+            f"No se puede resolver el host '{host}' (DNS/VPN). Detalle: {exc}"
+        ) from exc
 
-    def _try_connect(dsn):
-        return oracledb.connect(user=db["user"], password=db["password"], dsn=dsn)
 
-    # 2) Intento en thin con service_name
-    dsn = _dsn_service(host, port, service)
+def _build_dsn(host: str, port: int, *, service_name: str | None = None, sid: str | None = None) -> str:
+    if service_name:
+        return oracledb.makedsn(host, port, service_name=service_name)
+    if sid:
+        return oracledb.makedsn(host, port, sid=sid)
+    raise ValueError("Se requiere service_name o sid para construir el DSN")
+
+
+def _is_thin_not_supported(error: Exception) -> bool:
+    return "DPY-3010" in str(error)
+
+
+def _is_service_not_registered(error: Exception) -> bool:
+    message = str(error)
+    return "ORA-12514" in message or "ORA-12505" in message
+
+
+def _is_network_issue(error: Exception) -> bool:
+    message = str(error)
+    tokens = [
+        "ORA-12170",  # timeout
+        "ORA-12541",  # no listener
+        "ORA-12543",  # target host or object does not exist
+        "ORA-12545",  # host or object not known
+        "TNS:no listener",
+        "DPI-1060",
+        "DPI-1072",
+        "DPY-6006",
+        "DPY-6005",
+        "DPY-6011",
+    ]
+    return any(token in message for token in tokens)
+
+
+def _connect_direct(db: dict[str, Any], dsn: str) -> oracledb.Connection:
+    return oracledb.connect(
+        user=db["user"],
+        password=db["password"],
+        dsn=dsn,
+    )
+
+
+def _with_thick_retry(db: dict[str, Any], dsn: str) -> oracledb.Connection:
     try:
-        con = _try_connect(dsn)
-    except oracledb.DatabaseError as e:
-        msg = str(e)
-        # a) DB vieja no soporta thin -> cambiamos a thick y reintentamos
-        if "DPY-3010" in msg:
-            _init_thick_if_configured()
-            con = _try_connect(dsn)
-        # b) listener no conoce el service_name -> probamos con SID
-        elif "ORA-12514" in msg or "ORA-12505" in msg:
-            dsn_sid = _dsn_sid(host, port, service)
-            con = _try_connect(dsn_sid)
-        else:
-            raise
+        return _connect_direct(db, dsn)
+    except oracledb.DatabaseError as exc:
+        if _is_thin_not_supported(exc):
+            _require_thick_mode("el servidor Oracle remoto no soporta modo thin (DPY-3010)")
+            return _connect_direct(db, dsn)
+        raise
+
+
+def _handle_connection_error(error: Exception, host: str, port: int) -> None:
+    if _is_network_issue(error):
+        raise RuntimeError(_NETWORK_HINT.format(host=host, port=port, detail=error)) from error
+    raise error
+
+
+@contextmanager
+def connect(db: dict[str, Any]):
+    host, port, service_name, sid = _parse_connection_fields(db)
+    _resolve_dns(host)
+
+    if _should_force_thick():
+        _require_thick_mode("FORCE_ORACLE_THICK=1")
+
+    service_input = db["service"].strip()
+    service_dsn = _build_dsn(host, port, service_name=service_name) if service_name else None
+    sid_dsn = _build_dsn(host, port, sid=sid) if sid else None
+
+    connection = None
+    last_error: Exception | None = None
 
     try:
-        yield con
+        if service_dsn:
+            try:
+                connection = _with_thick_retry(db, service_dsn)
+            except Exception as exc:  # pragma: no cover - flujo de error
+                last_error = exc
+                if _is_service_not_registered(exc):
+                    fallback_sid_dsn = sid_dsn
+                    if fallback_sid_dsn is None and service_input:
+                        fallback_sid_dsn = _build_dsn(host, port, sid=service_input)
+
+                    if fallback_sid_dsn:
+                        last_error = None
+                        sid_dsn = fallback_sid_dsn
+                    else:
+                        _handle_connection_error(exc, host, port)
+                        raise
+                else:
+                    _handle_connection_error(exc, host, port)
+                    raise
+
+        if connection is None and sid_dsn:
+            try:
+                connection = _with_thick_retry(db, sid_dsn)
+            except Exception as exc:  # pragma: no cover - flujo de error
+                last_error = exc
+                _handle_connection_error(exc, host, port)
+                raise
+
+        if connection is None:
+            # Si todo falló y no tenemos errores específicos, levantamos el último.
+            if last_error:
+                raise last_error
+            raise RuntimeError("No se pudo establecer conexión con Oracle: parámetros incompletos")
+
+        yield connection
     finally:
-        try:
-            con.close()
-        except Exception:
-            pass
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception:
+                pass
 
-def fetch_all(con, sql: str, binds: dict) -> list[dict]:
-    # arraysize ajustable si querés performance: cur.arraysize = 1000
+
+def fetch_all(con: oracledb.Connection, sql: str, binds: dict) -> list[dict]:
     with con.cursor() as cur:
         cur.execute(sql, binds)
         rows = cur.fetchall()
         cols = [d[0].lower() for d in cur.description]
-    return [dict(zip(cols, r)) for r in rows]
+    return [dict(zip(cols, row)) for row in rows]
 
 
-def fetch_count(con, sql: str, binds: dict) -> int:
+def fetch_count(con: oracledb.Connection, sql: str, binds: dict) -> int:
     with con.cursor() as cur:
         cur.execute(sql, binds)
         row = cur.fetchone()


### PR DESCRIPTION
## Summary
- add a more robust Oracle connection helper with automatic THICK retry on DPY-3010 and clearer error messages
- support FORCE_ORACLE_THICK/ORACLE_CLIENT_LIB_DIR env vars via backend .env example
- document THICK requirements, Windows setup steps, and SID syntax in the backend README sections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7781af5d4832cbb300f42c38cd935