### PR TITLE
Restrict records query to allowed level actions

### DIFF
--- a/backend/provisioning_api/db/sql/queries.py
+++ b/backend/provisioning_api/db/sql/queries.py
@@ -13,6 +13,8 @@ def build_sql(filters: dict, include_pagination: bool, use_legacy_pagination: bo
         "AND TO_DATE(:end_date,'YYYY-MM-DD HH24:MI:SS')",
         "a.pri_ne_id = :pri_ne_id",
     ]
+    # Restrict to allowed level actions
+    where.append("a.pri_level_action IN ('U','R')")
     binds = {
         "start_date": filters["start_date"],
         "end_date": filters["end_date"],


### PR DESCRIPTION
## Summary
- ensure the main provisioning records query always filters to level actions U and R

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f92107bca0832caa8a4471aff13a5f